### PR TITLE
Login email CSS hotfix

### DIFF
--- a/public/stylesheets/components/navbar.css
+++ b/public/stylesheets/components/navbar.css
@@ -120,6 +120,10 @@ SignUp form animations
     width: calc(100% - 30px);
 }
 
+.email-input {
+    text-transform: lowercase;
+}
+
 /*
 ================================
 Custom styling for the bootstrap nav

--- a/views/admin/settings.ejs
+++ b/views/admin/settings.ejs
@@ -64,7 +64,7 @@
 
                         <div class="form-group">
                             <label for="email-input">Required Email Extension (if left blank, none will be applied)</label><br/>
-                            <input id="email-input" class="form-control mode" type="text"
+                            <input id="email-input" class="form-control mode email-input" type="text"
                                     name="emailExtension" value="<%= platform.emailExtension %>" placeholder="Enter Required Email Extension">
                         </div>
                         <div class="form-group">

--- a/views/partials/components/navbar.ejs
+++ b/views/partials/components/navbar.ejs
@@ -238,7 +238,7 @@
         <span class="form-close login"><i class="far fa-window-close"></i></span>
         <div class="form-group mt-3">
             <label for="email-login">Email address</label>
-            <input name="email" class="form-control" id="email-login" placeholder="enter email">
+            <input name="email" class="form-control email-input" id="email-login" placeholder="enter email">
         </div>
         <div class="form-group">
             <label for="password-login">Password</label>
@@ -275,7 +275,7 @@
         <div class="login-info">
             <div class="form-group mt-3">
                 <label for="email-signup">Email address</label>
-                <input name="email" type="email" class="form-control" id="email-signup" aria-describedby="emailHelp">
+                <input name="email" type="email" class="form-control email-input" id="email-signup" aria-describedby="emailHelp">
                 <small id="emailHelp" class="form-text text-muted">Your email determines whether you are part of the
                     <%=platform.name%> community.</small>
             </div>

--- a/views/profiles/edit_pwd_email.ejs
+++ b/views/profiles/edit_pwd_email.ejs
@@ -21,7 +21,7 @@
                 <form action="/profiles/change-email?_method=put" method="post">
                     <div class="form-group mode">
                         <label for="usernameInput">Email</label>
-                        <input id="usernameInput" class="form-control mode" type="text" name="email" value="<%= currentUser.email %>" placeholder="Enter New Email" required><br />
+                        <input id="usernameInput" class="form-control mode email-input" type="text" name="email" value="<%= currentUser.email %>" placeholder="Enter New Email" required><br />
                         <input type="checkbox" name="receiving_emails" id="receiving_emails" <% if (currentUser.receiving_emails) {%> checked <%}%>/>
                         <label for="receiving_emails">Send Me Emails</label>
                     </div>

--- a/views/shop/menu.ejs
+++ b/views/shop/menu.ejs
@@ -138,7 +138,7 @@
                                    <label for="request-name-<%=item._id%>">Your Name</label>
                                    <input id="request-name-<%=item._id%>" class="form-control mode" type="text" placeholder="Enter your name" name="name" <% if (currentUser) {%>value="<%=currentUser.firstName%> <%=currentUser.lastName%>"<%}%> required><br>
                                    <label for="request-email-<%=item._id%>">Your Email Address</label>
-                                   <input id="request-email-<%=item._id%>" class="form-control mode" type="text" placeholder="Enter your email address" name="email" <%if (currentUser) { %>value="<%=currentUser.email%>"<%}%> required><br>
+                                   <input id="request-email-<%=item._id%>" class="form-control mode email-input" type="text" placeholder="Enter your email address" name="email" <%if (currentUser) { %>value="<%=currentUser.email%>"<%}%> required><br>
                                    <label for="request-address-<%=item._id%>">Your Mailing Address</label>
                                    <input id="request-address-<%=item._id%>" class="form-control mode" type="text" placeholder="Enter your mailing address" name="address" required><br>
                                    <label for="quantity--<%=item._id%>">Number Of Items</label>


### PR DESCRIPTION
Implemented CSS styling property that allows the text on login emails (as well as the "edit email" setting and elsewhere) to be automatically converted to lowercase when sent to the server.