### PR TITLE
Set up principal item availability control button

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -68,7 +68,7 @@ controller.updatePlatform = async function(req, res) {
         platform[attr] = req.body[attr];
     }
 
-    for (let attr of ["navDark", "contactPhotoDisplay", "postVerifiable", "enableDarkmode", "homepageInfo", "restrictPosts"]) {
+    for (let attr of ["displayAvailability", "navDark", "contactPhotoDisplay", "postVerifiable", "enableDarkmode", "homepageInfo", "restrictPosts"]) {
         platform[attr] = (req.body[attr] != undefined);
     }
 

--- a/controllers/shop.js
+++ b/controllers/shop.js
@@ -249,7 +249,7 @@ controller.order = async function(req, res) {
     }
 
     for (let item of orderedItems) { //Update items
-        if (item.displayAvailability) {
+        if (platform.displayAvailability && item.displayAvailability) {
             item.availableItems -= await parseInt(req.body[item.name]);
             item.orderCount += await parseInt(req.body[item.name]);
             await item.save();

--- a/models/platform.js
+++ b/models/platform.js
@@ -15,6 +15,7 @@ var platformSchema = new mongoose.Schema({
         url: String,
         originalName: String,
     },
+    displayAvailability: {type: Boolean, default: true}, //Display item availability
     homepageInfo: {type: Boolean, default: true}, //Display information on homepage
     descriptionDisplay: {type: Boolean, default: false}, //Display description or platform name first on homepage
     contactPhotoDisplay: {type: Boolean, default: true}, //Display photos of platform administrators on contact page

--- a/views/admin/settings.ejs
+++ b/views/admin/settings.ejs
@@ -100,6 +100,11 @@
                                 <br>
                             <% } %>
                         </div>
+
+                        <div class="form-group">
+                            <label for="item-display-input">Display Item Availability</label>
+                            <input id="item-display-input" class="mode" type="checkbox" name="displayAvailability" <% if (platform.displayAvailability) { %> checked <% } %>>
+                        </div>
                         
                         <div class="form-group">
                             <label for="display-input">Navbar Dark Display</label>

--- a/views/shop/manage.ejs
+++ b/views/shop/manage.ejs
@@ -78,14 +78,14 @@
                         <% if (item.availableItems > 0) { %>
                             <a href="/shop/item/<%= item._id %>" id="item-<%= item.id %>"
                                class="list-group-item list-group-item-action menu-item shop <%= category.name.replace(' ', '') %>"><span
-                                        class="item-name"><%= item.name %></span> <%if(item.displayAvailability){%>(<%= item.availableItems %> in stock)<%}%> <span class="upvote"
+                                        class="item-name"><%= item.name %></span> <%if (platform.displayAvailability && item.displayAvailability){%>(<%= item.availableItems %> in stock)<%}%> <span class="upvote"
                                                  title="Upvotes (Admins cannot upvote items from here)"></span><span
                                         id="upvoteCount-<%= item._id %>"
                                         class="upvote-count shoptext"> Upvotes: <%= item.upvotes.length %></span></a>
                         <% } else { %>
                             <a href="/shop/item/<%= item._id %>" id="item-<%= item.id %>"
                                class="list-group-item list-group-item-action menu-item shop <%= category.name.replace(' ', '') %>"><span
-                                        class="item-name"><%= item.name %></span> <%if(item.displayAvailability){%>(Unavailable)<%}%> <span class="upvote"
+                                        class="item-name"><%= item.name %></span> <%if (platform.displayAvailability && item.displayAvailability){%>(Unavailable)<%}%> <span class="upvote"
                                                                                                       title="Upvotes (Admins cannot upvote items from here)"></span><span
                                         id="upvoteCount-<%= item._id %>"
                                         class="upvote-count shoptext"> Upvotes: <%= item.upvotes.length %></span></a>

--- a/views/shop/menu.ejs
+++ b/views/shop/menu.ejs
@@ -73,7 +73,7 @@
                                     id="item-<%= item.id %>">
                             <% } %>
 
-                                <span class="item-name"><%= item.name %> <% if (item.displayAvailability){%>(<%= item.availableItems %> in stock)<%}%></span> - <% if (platform.dollarPayment) {%>$<%=(item.price).toFixed(2)%><% } else {%><%=(item.price)%> Credits<%}%>
+                                <span class="item-name"><%= item.name %> <% if (platform.displayAvailability && item.displayAvailability){%>(<%= item.availableItems %> in stock)<%}%></span> - <% if (platform.dollarPayment) {%>$<%=(item.price).toFixed(2)%><% } else {%><%=(item.price)%> Credits<%}%>
                                 <% if (currentUser) { %>
                                     <div title="Upvotes" class="upvotes">
                                         <% if (item.upvotes.includes(currentUser._id)) { %>

--- a/views/shop/newOrder.ejs
+++ b/views/shop/newOrder.ejs
@@ -105,7 +105,7 @@
                                                     <input name="<%=item.name%>" id="num-<%=item._id%>" type="text" class="form-control mode num-orders" hidden value="0" oninput="changeNumOrders(this, <%=item.availableItems%>, <%=platform.dollarPayment%>, <%=currentUser.darkmode%>)">
                                                     <label class="form-check-label" for="<%= item._id %>">
                                                         <span class="item-name"><%= item.name %></span>
-                                                        <%if(item.displayAvailability){%>(<%= item.availableItems %> order<%if(item.availableItems != 1){%>s<%}%> available)<%}%> -
+                                                        <%if (platform.displayAvailability && item.displayAvailability){%>(<%= item.availableItems %> order<%if(item.availableItems != 1){%>s<%}%> available)<%}%> -
                                                         <%if (platform.dollarPayment) {%>$<%= (item.price).toFixed(2)%><%} else {%> Credits: <%=item.price%><% } %>
                                                     </label>
 

--- a/views/shop/show.ejs
+++ b/views/shop/show.ejs
@@ -49,7 +49,7 @@
                             <input id="available" class="form-control mode" type="text" name="available" placeholder="Available Orders" value="<%= item.availableItems %>" maxlength="45" required>
                         </div>
                     </div>
-                    <input type="checkbox" name="displayAvailability" id="displayAvailability" <% if (item.displayAvailability){%>checked<%}%>/>
+                    <input type="checkbox" name="displayAvailability" id="displayAvailability" <% if (platform.displayAvailability && item.displayAvailability){%>checked<%}%>/>
                     <label for="displayAvailability">Display Item Availability</label>
                     <br><br>
 


### PR DESCRIPTION
This update allows platform principals to directly turn item availability display.